### PR TITLE
does wrap-reload need to enforce a 1-arg function?

### DIFF
--- a/ring-devel/src/ring/middleware/reload.clj
+++ b/ring-devel/src/ring/middleware/reload.clj
@@ -8,7 +8,7 @@
   from un-jarred source files, as apposed to source files in jars or compiled
   classes."
   [app reloadables]
-  (fn [req]
+  (fn [& args]
     (doseq [ns-sym reloadables]
       (require ns-sym :reload))
-    (app req)))
+    (apply app args)))

--- a/ring-devel/test/ring/middleware/reload_test.clj
+++ b/ring-devel/test/ring/middleware/reload_test.clj
@@ -7,3 +7,6 @@
 
 (deftest wrap-reload-smoke
   (is (= :response (app :request))))
+
+(deftest wrap-reload-for-multiple-args
+  (is (= :response (app :channel :request))))


### PR DESCRIPTION
So this isn't strictly a ring fix, but aleph is pretty similar, and the only thing keeping one from using ring.middleware.reload with aleph is the arity of the function returned by wrap-reload (aleph sends 2, ring gives 1).  This patch makes it work fine for both ring and aleph.  

Maybe this is just enforcing the 1-arg ring API, but it'd be nice to be able to use this with aleph.

p.s. Loving all the Ring blogs! Keep 'em coming!
