### PR TITLE
Allow custom options to wrap-file

### DIFF
--- a/ring-core/src/ring/middleware/file.clj
+++ b/ring-core/src/ring/middleware/file.clj
@@ -18,11 +18,13 @@
   wrapped app if such a file does not exist."
   [app ^String root-path]
   (ensure-dir root-path)
-  (fn [req]
+  (fn [req & opts]
     (if-not (= :get (:request-method req))
       (app req)
       (let [path (.substring (codec/url-decode (:uri req)) 1)]
         (or
           (response/file-response path
-            {:root root-path :index-files? true :html-files? true})
+            (into
+              {:root root-path :index-files? true :html-files? true}
+              (apply hash-map opts)))
           (app req))))))

--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -63,7 +63,7 @@
     (when-let [configurator (:configurator options)]
       (configurator s))
     (doto s
-      (.setHandler (proxy-handler handler))
+      (.addHandler (proxy-handler handler))
       (.start))
     (when (:join? options true)
       (.join s))


### PR DESCRIPTION
I ran into trouble with a web app where index.md was served as an index file. I discovered two things.

First, the options for file-response are hard-coded into wrap-file. Second, find-index-file accepts any file -- regardless of its extension -- as an index file.

The second might be desired behavior, but the first is definitely a problem.

My solution is backwards compatible, and allows people to (re)set options
