### PR TITLE
Allow for a IFn to be passed back as the body object

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -69,28 +69,25 @@
   "Update a HttpServletResponse body with a String, ISeq, File or InputStream."
   [^HttpServletResponse response, body]
   (cond
-    (string? body)
-      (with-open [writer (.getWriter response)]
-        (.println writer body))
-    (seq? body)
-      (with-open [writer (.getWriter response)]
-        (doseq [chunk body]
-          (.print writer (str chunk))
-          (.flush writer)))
-    (instance? InputStream body)
-    (let [^InputStream b body]
-      (with-open [out (.getOutputStream response)]
-        (copy b out)
-        (.close b)
-        (.flush out)))
-    (instance? File body)
-    (let [^File f body]
-      (with-open [stream (FileInputStream. f)]
-        (set-body response stream)))
-    (nil? body)
-      nil
-    :else
-      (throwf "Unrecognized body: %s" body)))
+   (fn? body) (with-open [out (.getOutputStream response)]
+		(body out)
+		(.flush out))
+   (seq? body) (with-open [writer (.getWriter response)]
+		 (doseq [chunk body]
+		   (.print writer (str chunk))
+		   (.flush writer)))
+   (instance? InputStream body) (let [^InputStream b body]
+				  (with-open [out (.getOutputStream response)]
+				    (copy b out)
+				    (.close b)
+				    (.flush out)))
+   (string? body) (with-open [writer (.getWriter response)]
+		    (.println writer body))
+   (instance? File body) (let [^File f body]
+			   (with-open [stream (FileInputStream. f)]
+			     (set-body response stream)))
+   (nil? body) nil
+   :else (throwf "Got an unrecognized body: %s" body)))
 
 (defn update-servlet-response
   "Update the HttpServletResponse using a response map."


### PR DESCRIPTION
I needed to be able to safely stream data out via a ring http server.  The way I came up with was by having the rendering logic open the output stream and then pass it back to a callback function which does the actual writing.  I have this running on our machines and it works, but it would be nice if it were incorporated into the actual system :).

Let me know if you need me to do anything to be able to get this merged in.
