### PR TITLE
Fix response body newline bug

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -75,7 +75,7 @@
   (cond
     (string? body)
       (with-open [writer (.getWriter response)]
-        (.println writer body))
+        (.print writer body))
     (seq? body)
       (with-open [writer (.getWriter response)]
         (doseq [chunk body]


### PR DESCRIPTION
just found out that the ring-servlet is appending a newline to the request body when it updates the HttpServletResponse with a string. this newline triggered a bug on some of our really strict client libraries and is (as far as i can see) appended without a reason. in order to fix this i just replaced the call to println with a call to print. although this is a really simple commit, we would love to see it in upstream and in the next release to be able to switch back to the official ring version. 

best regards
gugl
