### PR TITLE
Class loading issue causing resource-response to fail on some servlet containers

### DIFF
--- a/ring-core/src/ring/util/response.clj
+++ b/ring-core/src/ring/util/response.clj
@@ -61,8 +61,9 @@
     :root - take the resource relative to this root"
   [path & [opts]]
   (let [path (str (:root opts "") "/" path)
-        path (.replace path "//" "/")]
-    (if-let [resource (.getResourceAsStream System path)]
+        path (.replace path "//" "/")
+        path (.replaceAll path "^/" "")]
+    (if-let [resource (.. Thread currentThread getContextClassLoader (getResourceAsStream path))]
       (response resource))))
 
 (defn status

--- a/ring-core/test/ring/util/response_test.clj
+++ b/ring-core/test/ring/util/response_test.clj
@@ -2,6 +2,20 @@
   (:use clojure.test
         ring.util.response))
 
+(defmacro with-classloader
+  "Temporarily replaces the current context classloader with one that
+   includes everything in dir"
+  [[dir] & forms]
+  `(let [current-thread# (Thread/currentThread)
+         original-loader# (.getContextClassLoader current-thread#)
+         new-loader# (java.net.URLClassLoader. (into-array [(.toURL ~dir)])
+                                               original-loader#)]
+     (try
+	    (.setContextClassLoader current-thread# new-loader#)
+	    ~@forms
+	    (finally 
+		  (.setContextClassLoader current-thread# original-loader#)))))
+				
 (deftest test-redirect
   (is (= {:status 302 :headers {"Location" "http://google.com"} :body ""}
          (redirect "http://google.com"))))
@@ -28,6 +42,14 @@
   (let [resp (resource-response "response_test.clj" {:root "/ring/util"})]
     (is (.startsWith (slurp (resp :body))
                      "(ns ring.util.response-test"))))
-
+		
+(deftest test-resource-with-child-classloader
+  (let [resource (java.io.File/createTempFile "response_test" nil)]
+    (org.apache.commons.io.FileUtils/writeStringToFile resource "just testing") 
+    (with-classloader [(.getParentFile resource)]
+      (let [resp (resource-response (str (.getName resource)))]
+        (is (= (slurp (resp :body))
+              "just testing"))))))
+	
 (deftest test-missing-resource
   (is (nil? (resource-response "/missing/resource.clj"))))

--- a/ring-core/test/ring/util/response_test.clj
+++ b/ring-core/test/ring/util/response_test.clj
@@ -11,10 +11,10 @@
          new-loader# (java.net.URLClassLoader. (into-array [(.toURL ~dir)])
                                                original-loader#)]
      (try
-	    (.setContextClassLoader current-thread# new-loader#)
-	    ~@forms
-	    (finally 
-		  (.setContextClassLoader current-thread# original-loader#)))))
+        (.setContextClassLoader current-thread# new-loader#)
+        ~@forms
+        (finally 
+          (.setContextClassLoader current-thread# original-loader#)))))
 				
 (deftest test-redirect
   (is (= {:status 302 :headers {"Location" "http://google.com"} :body ""}
@@ -47,7 +47,7 @@
   (let [resource (java.io.File/createTempFile "response_test" nil)]
     (org.apache.commons.io.FileUtils/writeStringToFile resource "just testing") 
     (with-classloader [(.getParentFile resource)]
-      (let [resp (resource-response (str (.getName resource)))]
+      (let [resp (resource-response (.getName resource))]
         (is (= (slurp (resp :body))
               "just testing"))))))
 	


### PR DESCRIPTION
Ring currently uses the classloader that loaded java.lang.System in resource-response. This classloader doesn't necessarily have access to resources in the WAR, since it may well be higher in the classloader hierarchy. 

I think it's considered a best practice to [use the context classloader in situations like this](http://stackoverflow.com/questions/1771679/java-difference-between-threads-context-class-loader-and-normal-classloader/1772346#1772346). I've applied this change to my fork.

The problem is present at least in [Winstone](http://winstone.sourceforge.net/). [Tomcat documentation](http://tomcat.apache.org/tomcat-6.0-doc/class-loader-howto.html) implies it might also behave similarly, but I haven't yet checked this. 

I also added a test case which illustrates the problem.
