### PR TITLE
0.2 Fixing an issue with response body as InputStream

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -78,11 +78,10 @@
           (.print writer (str chunk))
           (.flush writer)))
     (instance? InputStream body)
-    (let [#^InputStream b body]
-      (with-open [out (.getOutputStream response)]
-        (copy b out)
-        (.close b)
-        (.flush out)))
+    (with-open [out (.getOutputStream response)
+                #^InputStream b body]
+      (copy b out)
+      (.flush out))
     (instance? File body)
     (let [#^File f body]
       (with-open [stream (FileInputStream. f)]


### PR DESCRIPTION
When the response body is an InputStream that gets copied to the response's OutputStream, if the OutputStream gets broken (e.g., the client interrupts the transfer), the InputStream will not get closed and the resources associated with it will not get released. Fixed by including the InputStream in with-open.

The same issue must be fixed on master.
