### PR TITLE
Fixing an issue with InputStream that represents response body not getting closed

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -82,11 +82,10 @@
           (.print writer (str chunk))
           (.flush writer)))
     (instance? InputStream body)
-      (let [^InputStream b body]
-        (with-open [out (.getOutputStream response)]
-          (io/copy b out)
-          (.close b)
-          (.flush out)))
+      (with-open [out (.getOutputStream response)
+                  ^InputStream b body]
+        (io/copy b out)
+        (.flush out))
     (instance? File body)
       (let [^File f body]
         (with-open [stream (FileInputStream. f)]


### PR DESCRIPTION
When the response body is an InputStream that gets copied to the response's OutputStream, if the OutputStream gets broken (e.g., the client interrupts the transfer), the InputStream will not get closed and the resources associated with it will not get released. Fixed by including the InputStream in with-open.
