### PR TITLE
SessionStore and wrap-session documentation

### DIFF
--- a/ring-core/src/ring/middleware/session.clj
+++ b/ring-core/src/ring/middleware/session.clj
@@ -11,9 +11,9 @@
 
   The following options are available:
     :store
-      An implementation map containing :read, :write, and :delete
-      keys. This determines how the session is stored. Defaults to
-      in-memory storage.
+      An implementation of ring.middleware.session.store.SessionStore protocol
+      This determines how the session is stored. Defaults to
+      ring.middleware.session.memory.MemoryStore.
     :root
       The root path of the session. Anything path above this will not
       be able to see this session. Equivalent to setting the cookie's

--- a/ring-core/src/ring/middleware/session/store.clj
+++ b/ring-core/src/ring/middleware/session/store.clj
@@ -2,6 +2,12 @@
   "Common session store objects and functions.")
 
 (defprotocol SessionStore
-  (read-session [store key] "Read a session map from the store.")
-  (write-session [store key data] "Write a session map to the store.")
-  (delete-session [store key] "Delete a session map from the store."))
+  (read-session [store key]
+   "Read a session map from the store. If the key is not found returns an
+   empty map")
+  (write-session [store key data]
+   "Write a session map to the store. Returns the (possibly changed) key under
+   which the data was stored. For new sessions a nil key could be passed.")
+  (delete-session [store key]
+   "Delete a session map from the store. Returns nil if the operation was
+   successful"))


### PR DESCRIPTION
I recently implemented a session store on top of Redis (https://github.com/paraseba/rrss), and I noticed some outdated and incomplete documentation for session store implementers.

My English is not very good, you may want to double check it.

Also, right now we require session stores to return nil on store deletion. I documented this, but I'm not sure it's the correct behavior, I know it's intended, since there is a test case about it. Maybe delete-session should be a no-fail operation, and we should disregard  the return value. What do you think about it? I may submit a patch if you want.

By the way, maybe you want to add my redis store library in the "Libraries" section of the wiki.
