### PR TITLE
ring.middleware.params: Use keywords for param keys

### DIFF
--- a/ring-core/src/ring/middleware/params.clj
+++ b/ring-core/src/ring/middleware/params.clj
@@ -21,7 +21,7 @@
     (fn [param-map encoded-param]
       (if-let [[_ key val] (re-matches #"([^=]+)=(.*)" encoded-param)]
         (assoc-param param-map
-          (codec/url-decode key encoding)
+          (keyword (codec/url-decode key encoding))
           (codec/url-decode (or val "") encoding))
          param-map))
     {}


### PR DESCRIPTION
The protocol between ring.middleware.params and compojure routes appears to have drifted since your [blog post](http://mmcgrana.github.com/2010/07/develop-deploy-clojure-web-applications.html) was authored. The example code demonstrates definition of a route with parameters defined as route arguments and parsed as post parameters. Current versions of compojure and ring no longer support this behavior; this is a patch to middleware.params which uses keywords for :params keys which allows compojure routes to bind them as expected.
