### PR TITLE
Add another handler body type: callback

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -70,7 +70,8 @@
     (.setContentType response content-type)))
 
 (defn- set-body
-  "Update a HttpServletResponse body with a String, ISeq, File or InputStream."
+  "Update a HttpServletResponse body with a String, ISeq, File,
+  InputStream or a callback fn, whose argument is responses OutputStream."
   [^HttpServletResponse response, body]
   (cond
     (string? body)
@@ -85,6 +86,10 @@
       (with-open [out (.getOutputStream response)
                   ^InputStream b body]
         (io/copy b out)
+        (.flush out))
+    (fn? body)
+      (with-open [out (.getOutputStream response)]
+        (body out)
         (.flush out))
     (instance? File body)
       (let [^File f body]


### PR DESCRIPTION
Hi!

I have a scenario, where I want to return a result of XSLT transformation (that's XML templating). I'm using a Saxon processor, which accepts OutputStream (or Writer) and serializes a formatted xml there.
Ideally this would be response's OutputStream, but in ring 0.3.6 there is no way to do it -- even with java's PipedStreams, the generated body would have to be held in memory and passed to ring-servlet/set-body.
I believe there might be more scenarios like this, and so made this simple addition.

Regards,

Martin.
