### PR TITLE
second attempt at cache-control middleware

### DIFF
--- a/ring-core/src/ring/middleware/cache.clj
+++ b/ring-core/src/ring/middleware/cache.clj
@@ -1,0 +1,13 @@
+(ns ring.middleware.cache
+  "Adds cache control headers to response"
+  (:require [ring.middleware.headers :as headers]))
+
+(defn wrap-cache-control
+   "Middleware to set the Cache-Control http header. Map entries with boolean
+   values either write their key if true, or nothing if false.
+   Example:
+   {:max-age 3600 :public false :must-revalidate true}
+   => Cache-Control: max-age=3600, must-revalidate"
+   [handler header-map]
+   (headers/wrap-headers handler
+     {"Cache-Control" (headers/header-options header-map ", ")}))

--- a/ring-core/src/ring/middleware/headers.clj
+++ b/ring-core/src/ring/middleware/headers.clj
@@ -1,0 +1,27 @@
+(ns ring.middleware.headers
+  "Common utilties for middleware"
+  (:use [clojure.contrib.java-utils :only (as-str)])
+  (:require [clojure.contrib.str-utils2 :as str] ))
+
+(defn header-option
+  "Converts a header option KeyValue into a string."
+  [[key val]]
+  (cond 
+    (true? val)  (as-str key)
+    (false? val) nil
+    :otherwise   (as-str key "=" val)))
+
+(defn header-options
+  "Converts a map into an HTTP header options string."
+  [m delimiter]
+  (str/join delimiter
+    (remove nil? (map header-option m))))
+
+(defn wrap-headers
+  "Merges a map of header name and values into the response.  Overwrites 
+   existing headers."
+  [handler headers]
+  (fn [request]
+    (if-let [response (handler request)]
+      (assoc response :headers
+             (merge (:headers response) headers)))))

--- a/ring-core/test/ring/middleware/cache_test.clj
+++ b/ring-core/test/ring/middleware/cache_test.clj
@@ -1,0 +1,29 @@
+(ns ring.middleware.cache-test
+  (:use clojure.test
+        ring.middleware.cache))
+
+(deftest wrap-cache-control-add-cache-control-header
+  (let [app (wrap-cache-control (constantly {:headers {} :body "body"}) {})]
+    (is (contains? (-> (app {})
+                       :headers) "Cache-Control"))))
+
+(deftest wrap-cache-control-adds-truthy-keys
+  (let [app (wrap-cache-control (constantly {:headers {} :body "body"}) {:foo false :bar true :baz false})]
+    (is (= (-> (app {})
+                       :headers
+                       (get "Cache-Control"))
+           "bar"))))
+
+(deftest wrap-cache-control-numbers-equals
+  (let [app (wrap-cache-control (constantly {:headers {} :body "body"}) {:max-age 3600})]
+    (is (= (-> (app {})
+               :headers
+               (get "Cache-Control"))
+           "max-age=3600"))))
+
+(deftest wrap-cache-control-comma-delimited
+  (let [app (wrap-cache-control (constantly {:headers {} :body "body"}) {:foo true :max-age 300})]
+    (is (= (-> (app {})
+               :headers
+               (get "Cache-Control"))
+           "foo, max-age=300"))))


### PR DESCRIPTION
This patch adds a middleware for setting HTTP headers, and specifically setting the cache-control headers. 

I made a first attempt at this last September, weavejester had comments on my patch, sorry it took so long. The first attempt was here: https://github.com/arohner/ring/commit/15c28175caf0bb4c43f95e65ff5343c92d0cd13d

It's been a long time since I wrote this, but I'm pretty sure it's a port of an existing middleware from pre-ring compojure.
