### PR TITLE
Set default character encoding for response to UTF-8

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -72,6 +72,7 @@
 (defn- set-body
   "Update a HttpServletResponse body with a String, ISeq, File or InputStream."
   [^HttpServletResponse response, body]
+  (.setCharacterEncoding response "UTF-8")
   (cond
     (string? body)
       (with-open [writer (.getWriter response)]


### PR DESCRIPTION
Hello!

I recently started to develop a web-application using ring and jetty and faced a problem with non-english content: letters in server response were substituted for question marks. Setting "character-encoding" in "Content-type" header didn't solve the problem and after short investigation I found problem here and fixed it. I hope it will be useful.

Thank you for your great work! Good luck!

Nick.

PS: Sorry for possible grammar mistakes. English isn't my native language.
