### PR TITLE
Set character encoding for response according to 'charset' field of 'Content-Type' header

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -67,6 +67,9 @@
         (.addHeader response key val))))
   ; Some headers must be set through specific methods
   (when-let [content-type (get headers "Content-Type")]
+    ; Parse charset and set response encoding from it or set UTF-8 by default
+    (let [encoding (or (second (re-find #"charset=(.+);?" content-type)) "utf-8")]
+      (.setCharacterEncoding response encoding))
     (.setContentType response content-type)))
 
 (defn- set-body


### PR DESCRIPTION
Hello again!

This is fixed fix for my last pull request. Hope I'm doing this right.

Regards, Nick.
