### PR TITLE
Here's a fix for the wrap-params issue

### DIFF
--- a/ring-core/src/ring/util/codec.clj
+++ b/ring-core/src/ring/util/codec.clj
@@ -14,7 +14,9 @@
   "Returns the form-url-decoded version of the given string, using either a
   specified encoding or UTF-8 by default."
   [encoded & [encoding]]
-  (URLDecoder/decode encoded (or encoding "UTF-8")))
+  (try
+    (URLDecoder/decode encoded (or encoding "UTF-8"))
+    (catch Exception e nil)))
 
 (defn base64-encode
   "Encode an array of bytes into a base64 encoded string."

--- a/ring-core/test/ring/util/codec_test.clj
+++ b/ring-core/test/ring/util/codec_test.clj
@@ -8,8 +8,11 @@
   (is (= "foo%FE%FF%00%2Fbar") (url-encode "foo/bar" "UTF-16")))
 
 (deftest test-url-decode
-  (is (= "foo/bar" (url-decode "foo%2Fbar")))
-  (is (= "foo/bar" (url-decode "foo%FE%FF%00%2Fbar" "UTF-16"))))
+  (testing "standard behavior"
+    (is (= "foo/bar" (url-decode "foo%2Fbar")))
+    (is (= "foo/bar" (url-decode "foo%FE%FF%00%2Fbar" "UTF-16"))))
+  (testing "returns nil when underlying Java methods throw an exception"
+    (is (nil? (url-decode "%")))))
 
 (deftest test-base64-encoding
   (let [str-bytes (.getBytes "foo?/+" "UTF-8")]


### PR DESCRIPTION
I played around with several variations of this, but in the end it seems best to just fall out to nil when it can't decode a parameter.  I tried this by patching the jar in place on my project and things worked just fine.  
