### PR TITLE
Fix for wrap-nested-params and multi-valued parameters without '[]'

### DIFF
--- a/ring-core/test/ring/middleware/nested_params_test.clj
+++ b/ring-core/test/ring/middleware/nested_params_test.clj
@@ -15,4 +15,7 @@
         {"foo[]" "bar"}         {"foo" ["bar"]}
         {"foo[]" ["bar" "baz"]} {"foo" ["bar" "baz"]}
         {"a[x][]" ["b"], "a[x][][y]" "c"} {"a" {"x" ["b" {"y" "c"}]}}
-        {"a[][x]" "c", "a[][y]" "d"}      {"a" [{"x" "c"} {"y" "d"}]}))))
+        {"a[][x]" "c", "a[][y]" "d"}      {"a" [{"x" "c"} {"y" "d"}]}))
+    (testing "properly handle multi-valued parameters that don't end with '[]' (created by e.g., multiple select elements)"
+      (are [p r] (= (handler {:params p}) r)
+           {"foo" ["bar" "baz"]} {"foo" ["bar" "baz"]}))))


### PR DESCRIPTION
I recently had to use a multiple select box on an HTML form, but didn't end the parameter name with "[]".  wrap-params correctly transforms "foo=bar&foo=baz" into {"foo" ["bar" "baz"]}, but because the parameter was "foo" and not "foo[]", wrap-nested-params turned it into {"foo" "baz"}, eating all but the last value.

While this can be "fixed" by just calling the parameter "foo[]" from the beginning, it makes that a special case; you don't have to think about the brackets and whatnot when using the 'with-groups' macro in Hiccup, for instance (can't speak for other libraries like Enlive, though).  In any event, wrap-nested-params was removing legitimate parameter values.

There is probably a better way to go about this; I just added another key to the middleware options map for a "multi-value-suffix" that defaults to "[]", in keeping with using the parse-nested-keys default parse function.  Basically, if a multi-valued parameter is detected whose name doesn't end in the specified suffix, it gets added in the param-pairs function, making it appear "correct" to the rest of the machinery.  It works, though.

Thanks,
Chris
