### PR TITLE
Make Jetty SSL Connector respect :host option

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -24,6 +24,7 @@
   (let [ssl-connector (SslSocketConnector.)]
     (doto ssl-connector
       (.setPort        (options :ssl-port 443))
+      (.setHost        (options :host))
       (.setKeystore    (options :keystore))
       (.setKeyPassword (options :key-password)))
     (when (options :truststore)


### PR DESCRIPTION
In ring.adapter.jetty/run-jetty, the :host option is used for the non-SSL Connector, but not for the SSL Connector.

This means that the SSL Connector binds to 0.0.0.0 even if :host is set, which is unexpected behavior.
