### PR TITLE
wrap-session middleware doesn't url-decode the cookie before using it.

### DIFF
--- a/ring-core/src/ring/middleware/session.clj
+++ b/ring-core/src/ring/middleware/session.clj
@@ -1,7 +1,8 @@
 (ns ring.middleware.session
   "Session manipulation."
   (:use ring.middleware.cookies
-        [ring.middleware.session store memory]))
+        [ring.middleware.session store memory])
+  (:import [java.net URLDecoder]))
 
 (defn wrap-session
   "Reads in the current HTTP session map, and adds it to the :session key on
@@ -34,7 +35,8 @@
            cookie-attrs (merge (options :cookie-attrs) {:path session-root})]
       (wrap-cookies
         (fn [request]
-          (let [sess-key (get-in request [:cookies cookie-name :value])
+          (let [sess-key (if-let [sk (get-in request [:cookies cookie-name :value])]
+                           (URLDecoder/decode sk "UTF-8"))
                 session  (read-session store sess-key)
                 request  (assoc request :session session)]
             (if-let [response (handler request)]


### PR DESCRIPTION
I faced a weird bug today wherein the browser was sending the cookie string back to the server after url-encoding it and wrap-session tried decrypting the cookie without decoding the encoded cookie.

I am attaching a trivial patch that fixes the problem. url-decoding is idempotent so it won't affect anything even when the cookie is not url-encoded.
