### PR TITLE
Make sure regexp is performed against a string.

### DIFF
--- a/ring-core/src/ring/middleware/nested_params.clj
+++ b/ring-core/src/ring/middleware/nested_params.clj
@@ -6,7 +6,7 @@
     \"foo[bar][][baz]\"
     => [\"foo\" \"bar\" \"\" \"baz\"]"
   [param-name]
-  (let [[_ k ks] (re-matches #"(.*?)((?:\[.*?\])*)" param-name)
+  (let [[_ k ks] (re-matches #"(.*?)((?:\[.*?\])*)" (name param-name))
         keys     (if ks (map second (re-seq #"\[(.*?)\]" ks)))]
     (cons k keys)))
 


### PR DESCRIPTION
Make sure regexp is performed against a string. This helps the rare case where keyword params already exist at this point.
