### PR TITLE
Don't close Outputstream (when using InputStream :body)

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -103,10 +103,8 @@
           (.print writer (str chunk))
           (.flush writer)))
     (instance? InputStream body)
-      (with-open [out (.getOutputStream response)
-                  ^InputStream b body]
-        (io/copy b out)
-        (.flush out))
+      (with-open [^InputStream b body]
+        (io/copy b (.getOutputStream response)))
     (instance? File body)
       (let [^File f body]
         (with-open [stream (FileInputStream. f)]


### PR DESCRIPTION
Also don't flush the OutputStream. The Servlet Container will flush
and close the response OutputStream.

The current implementation closes the response OutputStream even though a client requests "keep-alive".
# Current:

w→ wget  -S  -O /dev/null  http://localhost:8080 http://localhost:8080
--2011-09-01 16:15:03--  http://localhost:8080/
Resolving localhost... ::1, 127.0.0.1
**Connecting to localhost|::1|:8080... connected.**
HTTP request sent, awaiting response... 
  HTTP/1.1 200 OK
  Content-Type: text/html
  Server: Jetty(6.1.26)
Length: unspecified [text/html]
Saving to: `/dev/null'
2011-09-01 16:15:03 (563 KB/s) -`/dev/null' saved [961]
--2011-09-01 16:15:03--  http://localhost:8080/
**Connecting to localhost|::1|:8080... connected.**
HTTP request sent, awaiting response... 
  HTTP/1.1 200 OK
  Content-Type: text/html
  Server: Jetty(6.1.26)
Length: unspecified [text/html]
Saving to: `/dev/null'
2011-09-01 16:15:03 (563 KB/s) -`/dev/null' saved [961]
FINISHED --2011-09-01 16:15:03--
Downloaded: 2 files, 1.9K in 0s (1.10 MB/s)
# With this patch applied:

→ wget   -O /dev/null  http://localhost:8080 http://localhost:8080
--2011-09-01 16:16:04--  http://localhost:8080/
Resolving localhost... ::1, 127.0.0.1
**Connecting to localhost|::1|:8080... connected.**
HTTP request sent, awaiting response... 200 OK
Length: 961 [text/html]
Saving to: `/dev/null'
2011-09-01 16:16:04 (563 KB/s) -`/dev/null' saved [961/961]
--2011-09-01 16:16:04--  http://localhost:8080/
**Reusing existing connection to localhost:8080.**
HTTP request sent, awaiting response... 200 OK
Length: 961 [text/html]
Saving to: `/dev/null'
2011-09-01 16:16:04 (563 KB/s) -`/dev/null' saved [961/961]
FINISHED --2011-09-01 16:16:04--
Downloaded: 2 files, 1.9K in 0s (1.10 MB/s)
