### PR TITLE
New SessionStore backed by HttpSession

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ ring-standalone.jar
 pom.xml
 autodoc
 .lein-failures
+*.iml
+.idea

--- a/ring-core/src/ring/middleware/session/httpsession.clj
+++ b/ring-core/src/ring/middleware/session/httpsession.clj
@@ -1,0 +1,56 @@
+(ns ring.middleware.session.httpsession
+  "SessionStore that uses the servlet container's HttpSession implementation, which
+  in some cases is configurable.  Very suitable for clustered environments like
+  Google App Engine where you want to ensure that the session is replicated
+  across servers automatically."
+  (:use ring.middleware.session.store)
+  (:import
+    (java.io ByteArrayInputStream ByteArrayOutputStream)
+    (java.io ObjectInputStream ObjectOutputStream)))
+
+(declare *session*)
+
+(defn serialize
+  "Uses Java object serialization to convert obj into a byte array. obj, and all its contents
+  must be primitives or implement java.io.Serializable."
+  [obj]
+  (let [bos (ByteArrayOutputStream.)]
+    (with-open [oos (ObjectOutputStream. bos)]
+      (.writeObject oos obj))
+    (.toByteArray bos)))
+
+(defn deserialize
+  "Uses Java object serialization to convert bytes into a Java object"
+  [bytes]
+  (let [bis (ByteArrayInputStream. bytes)]
+    (with-open [ois (ObjectInputStream. bis)]
+      (.readObject ois))))
+
+; SessionStore implementation backed by the HttpSession for the current user.
+; session-key is used as the single HttpSession attribute for the entire ring
+; session.
+(deftype HttpSessionStore
+  [session-key]
+  SessionStore
+  (read-session [_ _]
+    (let [val (.getAttribute *session* session-key)]
+      (if val (deserialize val) {})))
+  (write-session [_ key data]
+    (.setAttribute *session* session-key (serialize data))
+    key)
+  (delete-session [_ _]
+    (.removeAttribute *session* session-key)
+    nil))
+
+(defn http-session-store
+  "Creates a HttpSessionStore with the given key.  Each unique ring application
+  should use a different session-key to avoid collisions."
+  [session-key]
+  (HttpSessionStore. session-key))
+
+(defn wrap-http-session-store
+  "Middleware hook for HttpSessionStore"
+  [handler]
+  (fn [request]
+    (binding [*session* (.getSession (:request request))]
+      (handler request))))

--- a/ring-core/test/ring/middleware/session/test/httpsession.clj
+++ b/ring-core/test/ring/middleware/session/test/httpsession.clj
@@ -1,0 +1,46 @@
+(ns ring.middleware.session.test.httpsession
+  (:use clojure.test
+        [ring.middleware.session store httpsession])
+  (:import
+    (javax.servlet.http HttpSession HttpServletRequest)))
+
+(defn mock-session []
+  (let [data (atom {})]
+    (proxy [HttpSession] []
+      (getAttribute [key] (@data key))
+      (setAttribute [key val] (swap! data assoc key val))
+      (removeAttribute [key] (swap! data dissoc key)))))
+
+(defn mock-request []
+  (proxy [HttpServletRequest] []
+    (getSession [] (mock-session))))
+
+(declare *store*)
+
+(defn wrap-test
+  [test-fn]
+  (binding [*store* (http-session-store "test-app")]
+    ((wrap-http-session-store test-fn) { :request (mock-request) })))
+
+(deftest http-session-read-not-exist
+  (wrap-test (fn [_]
+    (is (read-session *store* "non-existent")))))
+
+(deftest http-session-session-create
+  (wrap-test (fn [_]
+    (let [sess-key (write-session *store* nil {:foo "bar"})]
+      (is (read-session *store* "non-existent"))))))
+
+(deftest http-session-session-update
+  (wrap-test (fn [_]
+    (let [sess-key  (write-session *store* nil {:foo "bar"})]
+      ;; this store ignores session key, as the container
+      ;; is scoping the session automatically for us
+      (is (= (read-session *store* sess-key) {:foo "bar"}))
+      (is (= (read-session *store* "blah") {:foo "bar"}))))))
+
+(deftest http-session-session-delete
+  (wrap-test (fn [_]
+    (let [sess-key  (write-session *store* nil {:foo "bar"})
+          sess-key* (delete-session *store* sess-key)]
+      (is (= (read-session *store* sess-key*) {}))))))


### PR DESCRIPTION
Hi,

On the noir group we've been discussing Google App Engine deploys which are clustered.  We agreed it would be useful to have a ring SessionStore that targeted the HttpSession provided by the servlet container.  The storage semantics of the session would consequently be delegated to the container, which may store it in a db, replicate it, etc.

You'll see that I'm not using the ring session-key, as the _session_ binding will already be scoped to the current request.

Implementation is provided + tests.  Java serialization is used.  I did some basic perf tests, and they seem fine.  Sub 1ms serialization times for sessions of 10kb on my MBP.  

Discussion of the general feature here:

https://groups.google.com/forum/#!topic/clj-noir/jM4SJb8NsDU

thank you,

-- James
