### PR TITLE
Allow for manual configuration of Jetty server in ring-adapter-jetty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ ring-standalone.jar
 pom.xml
 autodoc
 .lein-failures
+*.iml
+.idea

--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -58,14 +58,17 @@
     :keystore
     :key-password
     :truststore
-    :trust-password"
+    :trust-password
+    :default-handler? - Add a Jetty handler which proxies your hander: defaults
+                        to true, set to false if you want manually configure
+                        handlers with a configurator."
   [handler options]
   (let [^Server s (create-server (dissoc options :configurator))]
     (when-let [configurator (:configurator options)]
       (configurator s))
-    (doto s
-      (.addHandler (proxy-handler handler))
-      (.start))
+    (when (:default-handler? options true)
+      (.addHandler s (proxy-handler handler)))
+    (.start s)
     (when (:join? options true)
       (.join s))
     s))


### PR DESCRIPTION
Hello Mark, 

Would you consider including this changeset? It allows for manual configuration of the Jetty server  and is backwards compatible.

I have a use case where I need to do some extensive customization of the Jetty request handler to accomodate integration with other Java filters and servlets. The existing proxy-handler code in core.clj will not work for me because a proxy-handler is added unconditionally after a configurator runs. 

I still need to make use of the other connector options etc. which is why I think merging this change back makes sense.

Matt
