### PR TITLE
Support streaming

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -109,6 +109,8 @@
       (let [^File f body]
         (with-open [stream (FileInputStream. f)]
           (set-body response stream)))
+    (fn? body)
+      (body (.getOutputStream response))
     (nil? body)
       nil
     :else


### PR DESCRIPTION
The body can be a Fn that takes one argument that is the java.io.OutputStream to write the entity. This allows for streaming, for example, in conjunction with Compojure, an image does not need to be written to an ByteArrayOutputStream then those bytes copied to a ByteArrayInputStream, and then those bytes copied again to the servlet OutputStream:

<pre>
(extend-protocol Renderable
  BufferedImage
  (render [image _]
    (-> (ring.util.response/response #(ImageIO/write image "png" %1))
        (ring.util.response/content-type "image/png"))))
</pre>
