### PR TITLE
Add a few type hints to avoid reflection

### DIFF
--- a/ring-core/src/ring/middleware/session/cookie.clj
+++ b/ring-core/src/ring/middleware/session/cookie.clj
@@ -77,7 +77,7 @@
   (let [data (encrypt key (.getBytes (pr-str data)))]
     (str (codec/base64-encode data) "--" (hmac key data))))
 
-(defn- secure-compare [a b]
+(defn- secure-compare [^String a ^String b]
   (if (and a b (= (.length a) (.length b)))
       (= 0
          (reduce bit-or

--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -60,7 +60,7 @@
   [^HttpServletResponse response, status]
   (.setStatus response status))
 
-(defn set-content-type [response content-type]
+(defn set-content-type [^HttpServletResponse response content-type]
   (.setContentType
    response
    (-> content-type
@@ -73,7 +73,7 @@
        (re-find #"charset=(.+);?")
        (second)))
 
-(defn- set-character-encoding [response content-type]
+(defn- set-character-encoding [^HttpServletResponse response content-type]
   (when-let [charset (get-charset content-type)]
     (.setCharacterEncoding response charset)))
 


### PR DESCRIPTION
I have added a couple of type hints to ring.servlet & ring.core to fix reflection warnings.

All tests pass.
