### PR TITLE
parse-params public

### DIFF
--- a/ring-core/src/ring/middleware/multipart_params.clj
+++ b/ring-core/src/ring/middleware/multipart_params.clj
@@ -1,6 +1,6 @@
 (ns ring.middleware.multipart-params
   "Parse multipart upload into params."
-  (:use [ring.middleware.params :only (assoc-param)])
+  (:use [ring.util.codec :only (assoc-param)])
   (:import [org.apache.commons.fileupload.util Streams]
            [org.apache.commons.fileupload
              RequestContext

--- a/ring-core/src/ring/util/codec.clj
+++ b/ring-core/src/ring/util/codec.clj
@@ -52,3 +52,23 @@
          param-map))
     {}
     (string/split param-string #"&")))
+
+(defn form-encode
+  "Encode parameters from a map into a string."
+  ([param-map]
+     (form-encode param-map "UTF-8"))
+  ([param-map encoding]
+     (form-encode (keys param-map)
+                  (vals param-map)
+                  encoding))
+  ([params values encoding]
+     (string/join #"&"
+                  (map (fn [param value]
+                         (if (vector? value)
+                           (form-encode (repeat (count value) param)
+                                        value
+                                        encoding)
+                           (str (url-encode param)
+                                "="
+                                (url-encode value))))
+                       params values))))

--- a/ring-core/src/ring/util/codec.clj
+++ b/ring-core/src/ring/util/codec.clj
@@ -42,16 +42,18 @@
 
 (defn form-decode
   "Parse parameters from a string into a map."
-  [^String param-string encoding]
-  (reduce
-    (fn [param-map encoded-param]
-      (if-let [[_ key val] (re-matches #"([^=]+)=(.*)" encoded-param)]
-        (assoc-param param-map
-          (url-decode key encoding)
-          (url-decode (or val "") encoding))
-         param-map))
-    {}
-    (string/split param-string #"&")))
+  ([^String param-string]
+     (form-decode param-string "UTF-8"))
+  ([^String param-string encoding]
+     (reduce
+      (fn [param-map encoded-param]
+        (if-let [[_ key val] (re-matches #"([^=]+)=(.*)" encoded-param)]
+          (assoc-param param-map
+                       (url-decode key encoding)
+                       (url-decode (or val "") encoding))
+          param-map))
+      {}
+      (string/split param-string #"&"))))
 
 (defn form-encode
   "Encode parameters from a map into a string."

--- a/ring-core/test/ring/util/test/codec.clj
+++ b/ring-core/test/ring/util/test/codec.clj
@@ -17,3 +17,11 @@
 (deftest test-base64-encoding
   (let [str-bytes (.getBytes "foo?/+" "UTF-8")]
     (is (Arrays/equals str-bytes (base64-decode (base64-encode str-bytes))))))
+
+(deftest form-encoding
+  (let [encoded-params "p%2F1=v%2F1&p%2F2=v%2F21&p%2F2=v%2F22"]
+    (is (= (form-decode encoded-params)
+           (-> encoded-params
+               form-decode
+               form-encode
+               form-decode)))))


### PR DESCRIPTION
Hello,

I'd like to use `parse-params` in my code but it's private. This change makes it public, as it can be useful as generic query strring parser.

(for example I'd like to use it to capture query string parameters in hrefs when scraping web pages with enlive).

Maybe `parse-params` is private for a reason, in that case sorry for the noise. 

Cheers,
Giacomo
