### PR TITLE
A bit of humor for the MIT license on a Clojure project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ This project borrows heavily from Ruby's Rack and Python's WSGI; thanks to those
 
 ## License
 
-Copyright (c) 2009-2011 Mark McGranaghan and released under an MIT license.
+Copyright © 2009-2012 Mark McGranaghan.
+
+Distributed under the MIT License, the same as Node.js.
 
 Clojure logo by Tom Hickey.


### PR DESCRIPTION
I don't know how proud you are of your choice of the MIT license. Personally I quite like it and I think it's important for this project. I respect the choice of EPL for Clojure but I think for some projects it makes sense to make copying, pasting, and modifying a little easier.

I've been seeing _Distributed under the Eclipse Public License, the same as Clojure._ in most Clojure projects and I was reminded that it's created by leiningen project generators when I used lein-noir to create a new noir app. I thought it would be fun to take their template and change it a bit to match with the license I was using, MIT. Once I changed it on my unreleased project, I figured I'd see if the Ring maintainers would appreciate this change. So here it is.

I hope you like it. If not, I apologize.
