### PR TITLE
Support clj-time Intervals/DateTime for :max-age and :expires

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -5,6 +5,7 @@
                  [commons-codec "1.6"]
                  [commons-io "2.1"]
                  [commons-fileupload "1.2.1"]
-                 [javax.servlet/servlet-api "2.5"]]
+                 [javax.servlet/servlet-api "2.5"]
+                 [clj-time "0.3.7"]]
   :profiles
   {:dev {:dependencies [[org.clojure/clojure-contrib "1.2.0"]]}})


### PR DESCRIPTION
This fixes #55.

Each commit appears with a header and body description for what I've done.

Here's a quick summary:
1. clj-time is a dependency for ring-core
2. Tests check that `:max-age` and `:expires` accept an integer (as originally outlined)
3. `:max-age` now accepts an `Interval` — this is exercised through tests
4. `:expires` now accepts a `DateTime` — exercised through tests
5. Pre-conditions make sure that only those two keys take their respective object kinds

Let me know if any further work needs to be done.
