### PR TITLE
run-jetty :configurator set to run last

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -77,12 +77,12 @@
                   :want or :none (defaults to :none)"
   [handler options]
   (let [^Server s (create-server (dissoc options :configurator))]
-    (when-let [configurator (:configurator options)]
-      (configurator s))
     (doto s
       (.setHandler (proxy-handler handler))
-      (.setThreadPool (QueuedThreadPool. (options :max-threads 50)))
-      (.start))
+      (.setThreadPool (QueuedThreadPool. (options :max-threads 50))))
+    (when-let [configurator (:configurator options)]
+      (configurator s))
+    (.start s)
     (when (:join? options true)
       (.join s))
     s))

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -1,7 +1,10 @@
 (ns ring.adapter.test.jetty
   (:use clojure.test
         ring.adapter.jetty)
-  (:require [clj-http.client :as http]))
+  (:require [clj-http.client :as http])
+  (:import (org.eclipse.jetty.util.thread QueuedThreadPool)
+           (org.eclipse.jetty.server Server Request)
+           (org.eclipse.jetty.server.handler AbstractHandler)))
 
 (defn- hello-world [request]
   {:status  200
@@ -30,4 +33,15 @@
                   :key-password "password"}
       (let [response (http/get "https://localhost:4348" {:insecure? true})]
         (is (= (:status response) 200))
-        (is (= (:body response) "Hello World"))))))
+        (is (= (:body response) "Hello World")))))
+
+  (testing "configurator set to run last"
+    (let [max-threads 20 
+          new-handler  (proxy [AbstractHandler] [] (handle [_ ^Request base-request request response]))
+          threadPool (QueuedThreadPool. ({} :max-threads max-threads))
+          configurator (fn [server] (.setThreadPool server threadPool) (.setHandler server new-handler))
+          server (run-jetty hello-world {:join? false :port 4347 :configurator configurator})]
+      (is (= (.getMaxThreads (.getThreadPool server)) max-threads))
+      (is (identical? new-handler (.getHandler server)))
+      (is (= 1 (count (.getHandlers server))))
+      (.stop server))))


### PR DESCRIPTION
This change allows for replacing the default proxy-handler with a custom handler; the benefit of this (for us) was to allow for logging custom timing and request information from the handler in a way that provides a general solution without adding new configuration options.

The change simply rearranges what's already happening in the run-jetty function to allow the configurator to have the final say on what the configuration will be; it does not otherwise change the function's behavior.

Includes tests that demonstrate that the configurator can change the handler (and that it is the only handler) and the number of threads in the thread pool. Previously these two operations would be overwritten in run-jetty after the configurator was applied.
