### PR TITLE
Fixes for Issue#54.

### DIFF
--- a/ring-core/src/ring/util/resource.clj
+++ b/ring-core/src/ring/util/resource.clj
@@ -1,7 +1,7 @@
 (ns ring.util.resource
   "utility function for reading in resources"
-  (:require [clojure.java.io :as io])
-  )
+  (:use hiccup.core)
+  (:require [clojure.java.io :as io]))
 
 (defn style-resource [path]
   "Given a resource path, read the resource and return it as a html style element fragment"

--- a/ring-core/src/ring/util/resource.clj
+++ b/ring-core/src/ring/util/resource.clj
@@ -1,0 +1,8 @@
+(ns ring.util.resource
+  "utility function for reading in resources"
+  (:require [clojure.java.io :as io])
+  )
+
+(defn style-resource [path]
+  "Given a resource path, read the resource and return it as a html style element fragment"
+  (html [:style {:type "text/css"} (slurp (io/resource path))]))

--- a/ring-devel/resources/css/dump.css
+++ b/ring-devel/resources/css/dump.css
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2008, Yahoo! Inc. All rights reserved.
+Code licensed under the BSD License:
+http://developer.yahoo.net/yui/license.txt
+version: 2.6.0
+*/
+html{color:#000;background:#FFF;}body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0;}table{border-collapse:collapse;border-spacing:0;}fieldset,img{border:0;}address,caption,cite,code,dfn,em,strong,th,var{font-style:normal;font-weight:normal;}li{list-style:none;}caption,th{text-align:left;}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal;}q:before,q:after{content:'';}abbr,acronym{border:0;font-variant:normal;}sup{vertical-align:text-top;}sub{vertical-align:text-bottom;}input,textarea,select{font-family:inherit;font-size:inherit;font-weight:inherit;}input,textarea,select{*font-size:100%;}legend{color:#000;}del,ins{text-decoration:none;}
+
+h3.info {
+ font-size: 1.6em;
+ margin-left: 1em;
+ padding-top: .5em;
+ padding-bottom: .5em;
+}
+
+table.request {
+  font-size: 1.1em;
+  width: 800px;
+  margin-left: 1em;
+  margin-right: 1em;
+  background: lightgrey;
+}
+
+table.request tr {
+  line-height: 1.4em;
+}
+
+table.request td.key {
+  padding-left: .5em;
+  text-aligh: left;
+  width: 150px;
+}
+
+table.request td.val {
+  text-align: left;
+}

--- a/ring-devel/src/ring/handler/dump.clj
+++ b/ring-devel/src/ring/handler/dump.clj
@@ -11,7 +11,7 @@
 (def ring-keys
   '(:server-port :server-name :remote-addr :uri :query-string :scheme
     :request-method :content-type :content-length :character-encoding
-    :headers :body))
+    :ssl-client-cert :headers :body))
 
 (defhtml req-pair
   [key req]

--- a/ring-devel/src/ring/handler/dump.clj
+++ b/ring-devel/src/ring/handler/dump.clj
@@ -3,6 +3,7 @@
   (:use hiccup.core
         hiccup.page
         hiccup.def
+        ring.util.resource
         ring.util.response)
   (:require [clojure.set :as set]
             [clojure.pprint :as pprint]))

--- a/ring-devel/src/ring/handler/dump.clj
+++ b/ring-devel/src/ring/handler/dump.clj
@@ -7,7 +7,6 @@
   (:require [clojure.set :as set]
             [clojure.pprint :as pprint]))
 
-(declare css)
 
 (def ring-keys
   '(:server-port :server-name :remote-addr :uri :query-string :scheme
@@ -21,26 +20,25 @@
 
 (defhtml template
   [req]
-  (doctype :xhtml-transitional)
-  [:html {:xmlns "http://www.w3.org/1999/xhtml"}
-    [:head
-      [:meta {:http-equiv "Content-Type" :content "text/html"}]
-      [:title "Ring: Request Dump"]]
-      [:style {:type "text/css"} css]
-    [:body
-      [:div#content
-        [:h3.info "Ring Request Values"]
-        [:table.request
-          [:tbody
-            (for [key ring-keys]
-              (req-pair key req))]]
-        (if-let [user-keys (set/difference (set (keys req)) (set ring-keys))]
-          (html
-             [:br]
-             [:table.request.user
-               [:tbody [:tr
-                 (for [key (sort user-keys)]
-                   (req-pair key req))]]]))]]])
+  (html5
+   [:head
+    [:meta {:http-equiv "Content-Type" :content "text/html"}]
+    [:title "Ring: Request Dump"]]
+   (style-resource "css/dump.css")
+   [:body
+    [:div#content
+     [:h3.info "Ring Request Values"]
+     [:table.request
+      [:tbody
+       (for [key ring-keys]
+         (req-pair key req))]]
+     (if-let [user-keys (set/difference (set (keys req)) (set ring-keys))]
+       (html
+        [:br]
+        [:table.request.user
+         [:tbody [:tr
+                  (for [key (sort user-keys)]
+                    (req-pair key req))]]]))]]))
 
 (defn handle-dump
   "Returns a response tuple corresponding to an HTML dump of the request
@@ -51,41 +49,3 @@
   (-> (response (template req))
     (status 200)
     (content-type "text/html")))
-
-(def ^{:private true} css "
-/*
-Copyright (c) 2008, Yahoo! Inc. All rights reserved.
-Code licensed under the BSD License:
-http://developer.yahoo.net/yui/license.txt
-version: 2.6.0
-*/
-html{color:#000;background:#FFF;}body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0;}table{border-collapse:collapse;border-spacing:0;}fieldset,img{border:0;}address,caption,cite,code,dfn,em,strong,th,var{font-style:normal;font-weight:normal;}li{list-style:none;}caption,th{text-align:left;}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal;}q:before,q:after{content:'';}abbr,acronym{border:0;font-variant:normal;}sup{vertical-align:text-top;}sub{vertical-align:text-bottom;}input,textarea,select{font-family:inherit;font-size:inherit;font-weight:inherit;}input,textarea,select{*font-size:100%;}legend{color:#000;}del,ins{text-decoration:none;}
-
-h3.info {
- font-size: 1.6em; 
- margin-left: 1em;
- padding-top: .5em;
- padding-bottom: .5em;
-}
-
-table.request {
-  font-size: 1.1em;
-  width: 800px;
-  margin-left: 1em;
-  margin-right: 1em;
-  background: lightgrey;
-}
-
-table.request tr {
-  line-height: 1.4em;
-}
-
-table.request td.key {
-  padding-left: .5em;
-  text-aligh: left;
-  width: 150px;
-}
-
-table.request td.val {
-  text-align: left;
-}")

--- a/ring-devel/src/ring/middleware/stacktrace.clj
+++ b/ring-devel/src/ring/middleware/stacktrace.clj
@@ -1,11 +1,11 @@
 (ns ring.middleware.stacktrace
   "Catch exceptions and render web and log stacktraces for debugging."
-  (:require [clojure.java.io :as io])
   (:use hiccup.core
         hiccup.page
         clj-stacktrace.core
         clj-stacktrace.repl
-        ring.util.response))
+        ring.util.response
+        ring.util.resource))
 
 (defn wrap-stacktrace-log
   "Wrap a handler such that exceptions are logged to *err* and then rethrown."
@@ -17,9 +17,6 @@
         (let [msg (str "Exception: " (pst-str ex))]
           (.println *err* msg)
           (throw ex))))))
-
-(defn- style-resource [path]
-  (html [:style {:type "text/css"} (slurp (io/resource path))]))
 
 (defn- elem-partial [elem]
   (if (:clojure elem)


### PR DESCRIPTION
Fixed the described issues - moved private resource-style function to ring.util.resource for getting resource files as stylesheets.
dump would also return html5 now.
Ring keys updated to added ssl-client-cert as well.

All tests pass and also tested using a dummy ring app using handle-dump.
