### PR TITLE
Optional context configuation added to jetty

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -1,4 +1,4 @@
-(defproject ring/ring-jetty-adapter "1.0.2"
+(defproject ring/ring-jetty-adapter-with-context "1.0.2"
   :description "Ring Jetty adapter."
   :url "http://github.com/mmcgrana/ring"
   :dependencies [[ring/ring-core "1.0.2"]


### PR DESCRIPTION
Its now possible to add a context to the jetty adapter; 
enable jetty adapter to mimic the same context as when deploying a war file, then the filename is used as the context name.  

ex : customer.war in tomcat -> context is /customer ex: http://localhost:8080/customer
